### PR TITLE
Added background color for codesnippets in text

### DIFF
--- a/web/src/components/project.module.css
+++ b/web/src/components/project.module.css
@@ -105,3 +105,8 @@
 .bodyText {
   font-family: var(--font-family-txt);
 }
+
+code {
+  background-color: var(--color-code-background);
+  color: var(--color-code-text);
+}

--- a/web/src/styles/custom-properties.css
+++ b/web/src/styles/custom-properties.css
@@ -5,23 +5,24 @@ https://www.colourlovers.com/palette/4681998/Overtly_Laced_Boots
 @import url('https://fonts.googleapis.com/css?family=Karla:400,400i,700|Lato:400,400i&display=swap');
 */
 
-
 @import url('https://fonts.googleapis.com/css?family=Lato:400,400i|Josefin+Sans&display=swap');
 
 :root {
   --font-family-sans: 'Josefin Sans', sans-serif;
-  --font-family-txt:  'Lato', sans-serif;
+  --font-family-txt: 'Lato', sans-serif;
 
   --color-maintext: #ccc;
   --color-dark-gray: #fff;
   --color-gray: #697a90;
   --color-background: #1e1e1e;
+  --color-code-text: #ccc;
+  --color-code-background: rgb(77, 76, 76);
   --color-background2: #252626;
   --color-very-light-gray: #e7ebed;
   --color-white: #fff;
   --color-accent: #fff;
   --color-logo1: #ce9178;
-  --color-logo2:#5498d0;
+  --color-logo2: #5498d0;
 
   /* Typography */
   --unit: 16;


### PR DESCRIPTION
Added CSS for background and text color to highlight code snippets in body text. The colors are set as variables in the file custom-properties.css.